### PR TITLE
[don't merge] implement checks preview support (only needed with 2.22.2

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -43,6 +43,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
+
 	"k8s.io/test-infra/ghproxy/ghmetrics"
 )
 
@@ -183,7 +184,7 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	apiVersion := "v3"
-	if strings.HasPrefix(req.URL.Path, "graphql") || strings.HasPrefix(req.URL.Path, "/graphql") {
+	if strings.HasPrefix(req.URL.Path, "graphql") || strings.HasPrefix(req.URL.Path, "/graphql") || strings.Contains(req.URL.Path, "/graphql") {
 		resp.Header.Set("Cache-Control", "no-store")
 		apiVersion = "v4"
 	}

--- a/ghproxy/ghmetrics/ghpath.go
+++ b/ghproxy/ghmetrics/ghpath.go
@@ -150,6 +150,7 @@ var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the
 	l("teams"),
 	// end point for gh api v4
 	l("graphql"),
+	l("api", l("graphql")),
 	l("licenses")))
 
 // l and v keep the tree legible

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -81,6 +81,9 @@ type options struct {
 	upstream       string
 	upstreamParsed *url.URL
 
+	upstreamGraphQL       string
+	upstreamGraphQLParsed *url.URL
+
 	maxConcurrency int
 
 	// pushGateway fields are used to configure pushing prometheus metrics.
@@ -109,6 +112,12 @@ func (o *options) validate() error {
 		return fmt.Errorf("failed to parse upstream URL: %v", err)
 	}
 	o.upstreamParsed = upstreamURL
+
+	upstreamGraphQLURL, err := url.Parse(o.upstreamGraphQL)
+	if err != nil {
+		return fmt.Errorf("failed to parse upstream GraphQL URL: %v", err)
+	}
+	o.upstreamGraphQLParsed = upstreamGraphQLURL
 	return nil
 }
 
@@ -120,6 +129,7 @@ func flagOptions() *options {
 	flag.StringVar(&o.redisAddress, "redis-address", "", "Redis address if using a redis cache e.g. localhost:6379.")
 	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	flag.StringVar(&o.upstream, "upstream", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream.")
+	flag.StringVar(&o.upstreamGraphQL, "upstream-graphql", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream for GraphQL.")
 	flag.IntVar(&o.maxConcurrency, "concurrency", 25, "Maximum number of concurrent in-flight requests to GitHub.")
 	flag.StringVar(&o.pushGateway, "push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
 	flag.DurationVar(&o.pushGatewayInterval, "push-gateway-interval", time.Minute, "Interval at which prometheus metrics are pushed.")
@@ -162,8 +172,10 @@ func main() {
 		ServeMetrics: o.serveMetrics,
 	}, o.instrumentationOptions.MetricsPort)
 
-	proxy := newReverseProxy(o.upstreamParsed, cache, 30*time.Second)
-	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: proxy}
+	mux := http.NewServeMux()
+	mux.Handle("/", newReverseProxy(o.upstreamParsed, cache, 30*time.Second))
+	mux.Handle("/graphql", newReverseProxy(o.upstreamGraphQLParsed, cache, 30*time.Second))
+	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
 
 	health := pjutil.NewHealth()
 	health.ServeReady()

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -114,6 +114,7 @@ filegroup(
         "//prow/deck/jobs:all-srcs",
         "//prow/entrypoint:all-srcs",
         "//prow/external-plugins/cherrypicker:all-srcs",
+        "//prow/external-plugins/mention:all-srcs",
         "//prow/external-plugins/needs-rebase:all-srcs",
         "//prow/external-plugins/refresh:all-srcs",
         "//prow/flagutil:all-srcs",

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -114,6 +114,7 @@ filegroup(
         "//prow/deck/jobs:all-srcs",
         "//prow/entrypoint:all-srcs",
         "//prow/external-plugins/cherrypicker:all-srcs",
+        "//prow/external-plugins/lenses:all-srcs",
         "//prow/external-plugins/mention:all-srcs",
         "//prow/external-plugins/needs-rebase:all-srcs",
         "//prow/external-plugins/refresh:all-srcs",

--- a/prow/external-plugins/lenses/BUILD.bazel
+++ b/prow/external-plugins/lenses/BUILD.bazel
@@ -1,0 +1,82 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//prow:def.bzl", "prow_image")
+
+NAME = "lenses"
+
+prow_image(
+    name = "image",
+    base = ":lenses",
+    component = NAME,
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "lenses",
+    base = "@git-base//image",
+    data_path = "/prow/external-plugins/lenses",
+    directory = "/lenses",
+    files = [
+        ":resources",
+        ":templates",
+    ],
+)
+
+filegroup(
+    name = "templates",
+    srcs = [
+        "//prow/external-plugins/lenses/links:template",
+    ],
+)
+
+filegroup(
+    name = "resources",
+    srcs = [
+        "//prow/external-plugins/lenses/links:resources",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//prow/external-plugins/lenses/links:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/external-plugins/lenses",
+    deps = [
+        "//pkg/flagutil:go_default_library",
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/deck/jobs:go_default_library",
+        "//prow/external-plugins/lenses/links:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/interrupts:go_default_library",
+        "//prow/io:go_default_library",
+        "//prow/kube:go_default_library",
+        "//prow/spyglass:go_default_library",
+        "//prow/spyglass/lenses:go_default_library",
+        "//prow/spyglass/lenses/common:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
+    ],
+)

--- a/prow/external-plugins/lenses/BUILD.bazel
+++ b/prow/external-plugins/lenses/BUILD.bazel
@@ -69,7 +69,6 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/io:go_default_library",
-        "//prow/kube:go_default_library",
         "//prow/spyglass:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "//prow/spyglass/lenses/common:go_default_library",

--- a/prow/external-plugins/lenses/README.md
+++ b/prow/external-plugins/lenses/README.md
@@ -1,0 +1,24 @@
+
+# Deck
+
+## Debugging via Intellij / VSCode
+
+This section describes how to debug Deck locally by running it inside 
+VSCode or Intellij.
+
+```bash
+TEST_INFRA_DIR=${GOPATH}/src/k8s.io/test-infra
+
+# Prepare assets
+cd ${TEST_INFRA_DIR}
+bazel build //prow/external-plugins/lenses:image.tar
+mkdir -p /tmp/lenses
+tar -xvf ./bazel-bin/prow/external-plugins/lenses/lenses-layer.tar -C /tmp/lenses
+
+
+# Start Deck via go or in your IDE with the following arguments:
+--config-path=/home/sbuerin/code/src/git.daimler.com/c445/t1/prow/config/prow/config.yaml
+--job-config-path=/home/sbuerin/code/src/git.daimler.com/c445/t1/prow/config/jobs
+--s3-credentials-file=/tmp/s3.json
+--spyglass-files-location=/tmp/deck/lenses
+```

--- a/prow/external-plugins/lenses/links/BUILD.bazel
+++ b/prow/external-plugins/lenses/links/BUILD.bazel
@@ -1,0 +1,60 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["links.go"],
+    importpath = "k8s.io/test-infra/prow/external-plugins/lenses/links",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/spyglass/api:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+ts_library(
+    name = "script",
+    srcs = ["links.ts"],
+    deps = [
+        "//prow/spyglass/lenses:lens_api",
+    ],
+)
+
+rollup_bundle(
+    name = "script_bundle",
+    enable_code_splitting = False,
+    entry_point = ":links.ts",
+    deps = [
+        ":script",
+    ],
+)
+
+filegroup(
+    name = "resources",
+    srcs = [
+        "links.css",
+        ":script_bundle",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "template",
+    srcs = ["template.html"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/external-plugins/lenses/links/links.css
+++ b/prow/external-plugins/lenses/links/links.css
@@ -1,0 +1,8 @@
+body {
+    padding-left: 15px;
+    padding-bottom: 10px;
+}
+
+html {
+    overflow-x: hidden;
+}

--- a/prow/external-plugins/lenses/links/links.go
+++ b/prow/external-plugins/lenses/links/links.go
@@ -1,0 +1,176 @@
+// Package links provides a links viewer
+package links
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/spyglass/api"
+)
+
+var _ api.Lens = Lens{}
+
+// Lens implements the build lens.
+type Lens struct{}
+
+// Header executes the "header" section of the template.
+func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config json.RawMessage) string {
+	return executeTemplate(resourceDir, "header", View{})
+}
+
+// View holds data to render the body template
+type View struct {
+	Data  []DataRow
+	Links []LinkRow
+}
+
+type DataRow struct {
+	Name string
+	Data string
+}
+
+type LinkRow struct {
+	Name  string
+	Links []Link
+}
+
+type Link struct {
+	Text string
+	URL  string
+}
+
+type config struct {
+	BuildLogMetadata []configElement `json:"buildLogMetadata"`
+	BuildLogLinks    []configElement `json:"buildLogLinks"`
+	ArtifactLinks    []configElement `json:"artifactLinks"`
+}
+
+type configElement struct {
+	Name  string `json:"name"`
+	Regex string `json:"regex"`
+}
+
+// Body returns the <body> content
+func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string, rawConfig json.RawMessage) string {
+
+	var c config
+	if err := json.Unmarshal(rawConfig, &c); err != nil {
+		logrus.WithError(err).Error("Failed to decode lens config")
+		return ""
+	}
+
+	buildLogsView := View{}
+
+	// get build log
+	var lines []byte
+	var err error
+	for _, a := range artifacts {
+		if !strings.HasSuffix(a.JobPath(), "build-log.txt") {
+			continue
+		}
+
+		lines, err = a.ReadAll()
+		if err != nil {
+			logrus.WithError(fmt.Errorf("error matching log")).Info("")
+			continue
+		}
+	}
+
+	if len(lines) > 0 {
+		for _, buildLogMetadata := range c.BuildLogMetadata {
+			matches, err := matchRegex(lines, buildLogMetadata.Regex)
+			if err != nil {
+				logrus.WithError(err).Info("Error matching build log.")
+				continue
+			}
+			buildLogsView.Data = append(buildLogsView.Data, DataRow{Name: buildLogMetadata.Name, Data: strings.Join(matches, " ")})
+		}
+		for _, buildLogLink := range c.BuildLogLinks {
+			links, err := matchLinkRegex(lines, buildLogLink.Regex)
+			if err != nil {
+				logrus.WithError(err).Info("Error matching build log.")
+				continue
+			}
+			buildLogsView.Links = append(buildLogsView.Links, LinkRow{Name: buildLogLink.Name, Links: links})
+		}
+	}
+
+	for _, artifactLink := range c.ArtifactLinks {
+		var links []Link
+		for _, a := range artifacts {
+			if _, err := matchRegex([]byte(a.JobPath()), artifactLink.Regex); err != nil {
+				logrus.WithError(err).Info("Error matching build log.")
+				continue
+			}
+			links = append(links, Link{Text: path.Base(a.JobPath()), URL: a.CanonicalLink()})
+		}
+		if len(links) > 0 {
+			buildLogsView.Links = append(buildLogsView.Links, LinkRow{Name: artifactLink.Name, Links: links})
+		}
+	}
+	return executeTemplate(resourceDir, "body", buildLogsView)
+}
+
+func matchRegex(lines []byte, regexString string) ([]string, error) {
+	regex, err := regexp.Compile(regexString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex %q: %v", regex, err)
+	}
+
+	matches := regex.FindAllStringSubmatch(string(lines), -1)
+	if len(matches) < 1 {
+		return nil, fmt.Errorf("error matching log")
+	}
+	matchesArray := []string{}
+	for i := 0; i < len(matches); i++ {
+		if len(matches[0]) == 2 {
+			matchesArray = append(matchesArray, matches[i][1])
+		}
+	}
+	return matchesArray, nil
+}
+
+func matchLinkRegex(lines []byte, bld string) ([]Link, error) {
+	regex, err := regexp.Compile(bld)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex %q: %v", bld, err)
+	}
+
+	matches := regex.FindAllStringSubmatch(string(lines), -1)
+	if len(matches) < 1 {
+		return nil, fmt.Errorf("error matching log")
+	}
+	links := []Link{}
+	for i := 0; i < len(matches); i++ {
+		if len(matches[0]) == 3 {
+			links = append(links, Link{Text: matches[i][1], URL: strings.TrimSpace(matches[i][2])})
+		}
+	}
+	return links, nil
+}
+
+// Callback is unused
+func (lens Lens) Callback(artifacts []api.Artifact, resourceDir string, data string, rawConfig json.RawMessage) string {
+	return ""
+}
+
+func executeTemplate(resourceDir, templateName string, data interface{}) string {
+	t := template.New("template.html")
+	_, err := t.ParseFiles(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		return fmt.Sprintf("Failed to load template: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, templateName, data); err != nil {
+		logrus.WithError(err).Error("Error executing template.")
+	}
+	return buf.String()
+}

--- a/prow/external-plugins/lenses/links/template.html
+++ b/prow/external-plugins/lenses/links/template.html
@@ -1,0 +1,28 @@
+{{define "header"}}
+    <link rel="stylesheet" href="links.css">
+    <script type="text/javascript" src="script_bundle.min.js"></script>
+{{end}}
+{{define "body"}}
+    <table class="mdl-data-table mdl-js-data-table metadata-table" id="data-table">
+        <tbody>
+        {{range $key, $value := .Data}}
+            <tr>
+                <td class="mdl-data-table__cell--non-numeric">{{$value.Name}}</td>
+                <td class="mdl-data-table__cell--non-numeric">{{$value.Data}}</td>
+            </tr>
+        {{end}}
+        {{range $key, $value := .Links}}
+            <tr>
+                <td class="mdl-data-table__cell--non-numeric">{{$value.Name}}</td>
+                <td class="mdl-data-table__cell--non-numeric">
+                    {{range $key, $link := $value.Links}}
+                        <a href="{{$link.URL}}" target="_blank" style="padding-left:15px;">
+                            {{$link.Text}}
+                            <i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i>
+                        </a>
+                    {{end}}
+                </td>
+            </tr>
+        {{end}}
+    </table>
+{{end}}

--- a/prow/external-plugins/lenses/main.go
+++ b/prow/external-plugins/lenses/main.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Based on needs-rebase plugin
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+	"os"
+	"time"
+
+	coreapi "k8s.io/api/core/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"k8s.io/test-infra/prow/kube"
+
+	"k8s.io/test-infra/prow/external-plugins/lenses/links"
+	"k8s.io/test-infra/prow/spyglass/lenses"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/deck/jobs"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/io"
+	"k8s.io/test-infra/prow/spyglass"
+	"k8s.io/test-infra/prow/spyglass/lenses/common"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/pkg/flagutil"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+)
+
+type options struct {
+	port int
+
+	configPath    string
+	jobConfigPath string
+	pluginConfig  string
+
+	spyglassFilesLocation string
+
+	dryRun     bool
+	kubernetes prowflagutil.KubernetesOptions
+	storage    prowflagutil.StorageClientOptions
+
+	updatePeriod time.Duration
+
+	webhookSecretFile string
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
+	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
+	fs.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
+	fs.StringVar(&o.spyglassFilesLocation, "spyglass-files-location", "/lenses", "Location of the static files for spyglass.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	fs.DurationVar(&o.updatePeriod, "update-period", time.Hour*24, "Period duration for periodic scans of all PRs.")
+	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.storage} {
+		group.AddFlags(fs)
+	}
+	_ = fs.Parse(os.Args[1:])
+	return o
+}
+
+const spyglassLocalLensListenerAddr = "127.0.0.1:1235"
+
+func main() {
+	o := gatherOptions()
+
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+
+	configAgent := &config.Agent{}
+	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+
+	logLevel, err := logrus.ParseLevel(configAgent.Config().LogLevel)
+	if err != nil {
+		logrus.Fatalf("Could not parse loglevel %q: %v", configAgent.Config().LogLevel, err)
+	}
+	logrus.SetLevel(logLevel)
+
+	buildClusterClients, err := o.kubernetes.BuildClusterClients(configAgent.Config().PodNamespace, false)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Kubernetes client.")
+	}
+	podLogClients := make(map[string]jobs.PodLogClient)
+	for clusterContext, client := range buildClusterClients {
+		podLogClients[clusterContext] = &podLogClient{client: client}
+	}
+
+	restCfg, err := o.kubernetes.InfrastructureClusterConfig(false)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting infrastructure cluster config.")
+	}
+	mgr, err := manager.New(restCfg, manager.Options{
+		Namespace:          configAgent.Config().ProwJobNamespace,
+		MetricsBindAddress: "0",
+		LeaderElection:     false,
+	})
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting manager.")
+	}
+	// Force a cache for ProwJobs
+	if _, err := mgr.GetCache().GetInformer(&prowapi.ProwJob{}); err != nil {
+		logrus.WithError(err).Fatal("Failed to get prowjob informer")
+	}
+	go func() {
+		if err := mgr.Start(make(chan struct{})); err != nil {
+			logrus.WithError(err).Fatal("Error starting manager.")
+		} else {
+			logrus.Info("Manager stopped gracefully.")
+		}
+	}()
+	mgrSyncCtx, mgrSyncCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer mgrSyncCtxCancel()
+	if synced := mgr.GetCache().WaitForCacheSync(mgrSyncCtx.Done()); !synced {
+		logrus.Fatal("Timed out waiting for cachesync")
+	}
+
+	ja := jobs.NewJobAgent(context.Background(), &pjListingClientWrapper{mgr.GetClient()}, false, false, podLogClients, configAgent.Config)
+	ja.Start()
+
+	ctx := context.TODO()
+	opener, err := io.NewOpener(ctx, o.storage.GCSCredentialsFile, o.storage.S3CredentialsFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating opener")
+	}
+
+	localLenses := []common.LensWithConfiguration{
+		{
+			Config: common.LensOpt{
+				LensResourcesDir: lenses.ResourceDirForLens(o.spyglassFilesLocation, "links"),
+				LensName:         "links",
+				LensTitle:        "links",
+			},
+			Lens: links.Lens{},
+		},
+	}
+
+	lensServer, err := common.NewLensServer(spyglassLocalLensListenerAddr, ja, spyglass.NewStorageArtifactFetcher(opener, false), spyglass.NewPodLogArtifactFetcher(ja), configAgent.Config, localLenses)
+	if err != nil {
+		logrus.Fatalf("Failed to start lens server: %v", err)
+	}
+
+	interrupts.ListenAndServe(lensServer, 5*time.Second)
+
+	select {}
+}
+
+type podLogClient struct {
+	client corev1.PodInterface
+}
+
+func (c *podLogClient) GetLogs(name string) ([]byte, error) {
+	reader, err := c.client.GetLogs(name, &coreapi.PodLogOptions{Container: kube.TestContainerName}).Stream()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return ioutil.ReadAll(reader)
+}
+
+type pjListingClientWrapper struct {
+	reader ctrlruntimeclient.Reader
+}
+
+func (w *pjListingClientWrapper) List(
+	ctx context.Context,
+	pjl *prowapi.ProwJobList,
+	opts ...ctrlruntimeclient.ListOption) error {
+	return w.reader.List(ctx, pjl, opts...)
+}

--- a/prow/external-plugins/mention/BUILD.bazel
+++ b/prow/external-plugins/mention/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
+
+NAME = "mention"
+
+prow_image(
+    name = "image",
+    base = "@git-base//image",
+    component = NAME,
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/external-plugins/mention",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/flagutil:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/config/secret:go_default_library",
+        "//prow/external-plugins/mention/plugin:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/git/v2:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/interrupts:go_default_library",
+        "//prow/pluginhelp/externalplugins:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//prow/repoowners:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//prow/external-plugins/mention/plugin:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "mention",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/external-plugins/mention/main.go
+++ b/prow/external-plugins/mention/main.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Based on needs-rebase plugin
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/external-plugins/mention/plugin"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/repoowners"
+)
+
+type options struct {
+	port int
+
+	configPath    string
+	jobConfigPath string
+	pluginConfig  string
+
+	dryRun bool
+	github prowflagutil.GitHubOptions
+
+	updatePeriod time.Duration
+
+	webhookSecretFile string
+}
+
+func (o *options) Validate() error {
+	for idx, group := range []flagutil.OptionGroup{&o.github} {
+		if err := group.Validate(o.dryRun); err != nil {
+			return fmt.Errorf("%d: %w", idx, err)
+		}
+	}
+
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
+	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
+	fs.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	fs.DurationVar(&o.updatePeriod, "update-period", time.Hour*24, "Period duration for periodic scans of all PRs.")
+	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+
+	for _, group := range []flagutil.OptionGroup{&o.github} {
+		group.AddFlags(fs)
+	}
+	_ = fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.Fatalf("Invalid options: %v", err)
+	}
+
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+
+	configAgent := &config.Agent{}
+	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+
+	logLevel, err := logrus.ParseLevel(configAgent.Config().LogLevel)
+	if err != nil {
+		logrus.Fatalf("Could not parse loglevel %q: %v", configAgent.Config().LogLevel, err)
+	}
+	logrus.SetLevel(logLevel)
+	log := logrus.StandardLogger().WithField("plugin", plugin.PluginName)
+
+	secretAgent := &secret.Agent{}
+	if err := secretAgent.Start([]string{o.github.TokenPath, o.webhookSecretFile}); err != nil {
+		logrus.WithError(err).Fatal("Error starting secrets agent.")
+	}
+
+	pluginAgent := &plugins.ConfigAgent{}
+	if err := pluginAgent.Start(o.pluginConfig, false); err != nil {
+		log.WithError(err).Fatalf("Error loading plugin config from %q.", o.pluginConfig)
+	}
+
+	githubClient, err := o.github.GitHubClient(secretAgent, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
+	}
+	githubClient.Throttle(360, 360)
+
+	gitClient, err := o.github.GitClient(secretAgent, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Git client.")
+	}
+
+	mdYAMLEnabled := func(org, repo string) bool {
+		return pluginAgent.Config().MDYAMLEnabled(org, repo)
+	}
+	skipCollaborators := func(org, repo string) bool {
+		return pluginAgent.Config().SkipCollaborators(org, repo)
+	}
+	ownersDirBlacklist := func() config.OwnersDirBlacklist {
+		return configAgent.Config().OwnersDirBlacklist
+	}
+	ownersClient := repoowners.NewClient(git.ClientFactoryFrom(gitClient), githubClient, mdYAMLEnabled, skipCollaborators, ownersDirBlacklist)
+
+	server := &Server{
+		GitHubClient:   githubClient,
+		OwnersClient:   ownersClient,
+		tokenGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
+		ghc:            githubClient,
+		log:            log,
+	}
+
+	defer interrupts.WaitForGracefulShutdown()
+
+	mux := http.NewServeMux()
+	mux.Handle("/", server)
+	externalplugins.ServeExternalPluginHelp(mux, log, plugin.HelpProvider)
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
+	interrupts.ListenAndServe(httpServer, 5*time.Second)
+}
+
+// Server implements http.Handler. It validates incoming GitHub webhooks and
+// then dispatches them to the appropriate plugins.
+type Server struct {
+	GitHubClient   github.Client
+	OwnersClient   repoowners.Interface
+	tokenGenerator func() []byte
+	ghc            github.Client
+	log            *logrus.Entry
+}
+
+// ServeHTTP validates an incoming webhook and puts it into the event channel.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO: Move webhook handling logic out of hook binary so that we don't have to import all
+	// plugins just to validate the webhook.
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
+	if !ok {
+		return
+	}
+	_, _ = fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		logrus.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	l := s.log.WithFields(
+		logrus.Fields{
+			"event-type":     eventType,
+			github.EventGUID: eventGUID,
+		},
+	)
+	switch eventType {
+	case "pull_request":
+		var pre github.PullRequestEvent
+		if err := json.Unmarshal(payload, &pre); err != nil {
+			return err
+		}
+		go func() {
+			if err := plugin.HandlePullRequestEvent(l, s.GitHubClient, s.OwnersClient, &pre); err != nil {
+				l.WithField("event-type", eventType).WithError(err).Info("Error handling event.")
+			}
+		}()
+	default:
+		s.log.Debugf("received an event of type %q but didn't ask for it", eventType)
+	}
+	return nil
+}

--- a/prow/external-plugins/mention/plugin/BUILD.bazel
+++ b/prow/external-plugins/mention/plugin/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mention.go"],
+    importpath = "k8s.io/test-infra/prow/external-plugins/mention/plugin",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/repoowners:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mention_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//prow/labels:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/external-plugins/mention/plugin/mention.go
+++ b/prow/external-plugins/mention/plugin/mention.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/repoowners"
+)
+
+const (
+	// PluginName defines this plugin's registered name.
+	PluginName = "mention"
+
+	MentionNotificationName = "MENTIONNOTIFIER"
+)
+
+var (
+	notificationRegex = regexp.MustCompile(`(?is)^\[` + MentionNotificationName + `\] *?([^\n]*)(?:\n\n(.*))?`)
+)
+
+func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	return &pluginhelp.PluginHelp{
+			Description: "TODO: The owners-label plugin automatically adds labels to PRs based on the files they touch. Specifically, the 'labels' sections of OWNERS files are used to determine which labels apply to the changes. In our fork it also mentions the team if a team label is used. E.g. the label team/core-platform leads to a mention of @c445/core-platform",
+		},
+		nil
+}
+
+type ownersClient interface {
+	FindLabelsForFile(path string) sets.String
+}
+
+type githubClient interface {
+	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
+	DeleteComment(org, repo string, ID int) error
+	CreateComment(org, repo string, number int, comment string) error
+	BotName() (string, error)
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+}
+
+func HandlePullRequestEvent(log *logrus.Entry, githubClient github.Client, ownersClient repoowners.Interface, pre *github.PullRequestEvent) error {
+	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionReopened && pre.Action != github.PullRequestActionSynchronize {
+		return nil
+	}
+
+	oc, err := ownersClient.LoadRepoOwners(pre.Repo.Owner.Login, pre.Repo.Name, pre.PullRequest.Base.Ref)
+	if err != nil {
+		return fmt.Errorf("error loading RepoOwners: %v", err)
+	}
+
+	return handle(githubClient, oc, log, pre)
+}
+
+func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.PullRequestEvent) error {
+	org := pre.Repo.Owner.Login
+	repo := pre.Repo.Name
+	number := pre.Number
+
+	// First see if there are any labels requested based on the files changed.
+	changes, err := ghc.GetPullRequestChanges(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("error getting PR changes: %v", err)
+	}
+	neededLabels := sets.NewString()
+	for _, change := range changes {
+		neededLabels.Insert(oc.FindLabelsForFile(change.Filename).List()...)
+	}
+	if neededLabels.Len() == 0 {
+		// No labels requested for the given files. Return now to save API tokens.
+		return nil
+	}
+
+	if err = updateMentionComment(ghc, log, pre, neededLabels); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func updateMentionComment(ghc githubClient, log *logrus.Entry, pre *github.PullRequestEvent, neededLabels sets.String) error {
+
+	fetchErr := func(context string, err error) error {
+		return fmt.Errorf("failed to get %s for %s#%d: %v", context, pre.Repo.FullName, pre.PullRequest.Number, err)
+	}
+
+	botName, err := ghc.BotName()
+	if err != nil {
+		return fetchErr("bot name", err)
+	}
+	issueComments, err := ghc.ListIssueComments(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number)
+	if err != nil {
+		return fetchErr("issue comments", err)
+	}
+	commentsFromIssueComments := commentsFromIssueComments(issueComments)
+
+	notifications := filterComments(commentsFromIssueComments, notificationMatcher(botName))
+	latestNotification := getLast(notifications)
+	newMessage := updateNotification(neededLabels, pre.Repo.Owner.Login, latestNotification)
+	if newMessage != nil {
+		for _, notif := range notifications {
+			if err := ghc.DeleteComment(pre.Repo.Owner.Login, pre.Repo.Name, notif.ID); err != nil {
+				log.WithError(err).Errorf("Failed to delete comment from %s/%s#%d, ID: %d.", pre.Repo.Owner.Login, pre.Repo.Name, pre.Number, notif.ID)
+			}
+		}
+		if err := ghc.CreateComment(pre.Repo.Owner.Login, pre.Repo.Name, pre.Number, *newMessage); err != nil {
+			log.WithError(err).Errorf("Failed to create comment on %s/%s#%d: %q.", pre.Repo.Owner.Login, pre.Repo.Name, pre.Number, *newMessage)
+		}
+	}
+	return nil
+}
+
+func updateNotification(neededLabels sets.String, org string, latestNotification *comment) *string {
+	var teams []string
+	for _, label := range neededLabels.List() {
+		if strings.HasPrefix(label, "team/") {
+			teams = append(teams, fmt.Sprintf("@%s/%s", org, strings.TrimPrefix(label, "team/")))
+
+		}
+	}
+	message := fmt.Sprintf("[%s]: Please take a look: %s", MentionNotificationName, strings.Join(teams, " "))
+	if latestNotification != nil && strings.Contains(latestNotification.Body, message) {
+		return nil
+	}
+	return &message
+}
+
+func notificationMatcher(botName string) func(*comment) bool {
+	return func(c *comment) bool {
+		if c.Author != botName {
+			return false
+		}
+		match := notificationRegex.FindStringSubmatch(c.Body)
+		return len(match) > 0
+	}
+}
+
+type comment struct {
+	Body        string
+	Author      string
+	CreatedAt   time.Time
+	HTMLURL     string
+	ID          int
+	ReviewState github.ReviewState
+}
+
+func commentFromIssueComment(ic *github.IssueComment) *comment {
+	if ic == nil {
+		return nil
+	}
+	return &comment{
+		Body:      ic.Body,
+		Author:    ic.User.Login,
+		CreatedAt: ic.CreatedAt,
+		HTMLURL:   ic.HTMLURL,
+		ID:        ic.ID,
+	}
+}
+
+func commentsFromIssueComments(ics []github.IssueComment) []*comment {
+	comments := make([]*comment, 0, len(ics))
+	for i := range ics {
+		comments = append(comments, commentFromIssueComment(&ics[i]))
+	}
+	return comments
+}
+
+func filterComments(comments []*comment, filter func(*comment) bool) []*comment {
+	filtered := make([]*comment, 0, len(comments))
+	for _, c := range comments {
+		if filter(c) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+func getLast(cs []*comment) *comment {
+	if len(cs) == 0 {
+		return nil
+	}
+	return cs[len(cs)-1]
+}

--- a/prow/external-plugins/mention/plugin/mention_test.go
+++ b/prow/external-plugins/mention/plugin/mention_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/labels"
+)
+
+func formatLabels(labels ...string) []string {
+	r := []string{}
+	for _, l := range labels {
+		r = append(r, fmt.Sprintf("%s/%s#%d:%s", "org", "repo", 1, l))
+	}
+	if len(r) == 0 {
+		return nil
+	}
+	return r
+}
+
+type fakeOwnersClient struct {
+	labels map[string]sets.String
+}
+
+func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.String {
+	return foc.labels[path]
+}
+
+// TestHandle tests that the handle function requests reviews from the correct number of unique users.
+func TestHandle(t *testing.T) {
+	foc := &fakeOwnersClient{
+		labels: map[string]sets.String{
+			"a.go": sets.NewString(labels.LGTM, labels.Approved, "kind/docs"),
+			"b.go": sets.NewString(labels.LGTM),
+			"c.go": sets.NewString(labels.LGTM, "dnm/frozen-docs"),
+			"d.sh": sets.NewString("dnm/bash"),
+			"e.sh": sets.NewString("dnm/bash"),
+		},
+	}
+
+	type testCase struct {
+		name              string
+		filesChanged      []string
+		expectedNewLabels []string
+		repoLabels        []string
+		issueLabels       []string
+	}
+	testcases := []testCase{
+		{
+			name:              "no labels",
+			filesChanged:      []string{"other.go", "something.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "1 file 1 label",
+			filesChanged:      []string{"b.go"},
+			expectedNewLabels: formatLabels(labels.LGTM),
+			repoLabels:        []string{labels.LGTM},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "1 file 3 labels",
+			filesChanged:      []string{"a.go"},
+			expectedNewLabels: formatLabels(labels.LGTM, labels.Approved, "kind/docs"),
+			repoLabels:        []string{labels.LGTM, labels.Approved, "kind/docs"},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "2 files no overlap",
+			filesChanged:      []string{"c.go", "d.sh"},
+			expectedNewLabels: formatLabels(labels.LGTM, "dnm/frozen-docs", "dnm/bash"),
+			repoLabels:        []string{labels.LGTM, "dnm/frozen-docs", "dnm/bash"},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "2 files partial overlap",
+			filesChanged:      []string{"a.go", "b.go"},
+			expectedNewLabels: formatLabels(labels.LGTM, labels.Approved, "kind/docs"),
+			repoLabels:        []string{labels.LGTM, labels.Approved, "kind/docs"},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "2 files complete overlap",
+			filesChanged:      []string{"d.sh", "e.sh"},
+			expectedNewLabels: formatLabels("dnm/bash"),
+			repoLabels:        []string{"dnm/bash"},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "3 files partial overlap",
+			filesChanged:      []string{"a.go", "b.go", "c.go"},
+			expectedNewLabels: formatLabels(labels.LGTM, labels.Approved, "kind/docs", "dnm/frozen-docs"),
+			repoLabels:        []string{labels.LGTM, labels.Approved, "kind/docs", "dnm/frozen-docs"},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "no labels to add, initial unrelated label",
+			filesChanged:      []string{"other.go", "something.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{labels.LGTM},
+			issueLabels:       []string{labels.LGTM},
+		},
+		{
+			name:              "1 file 1 label, already present",
+			filesChanged:      []string{"b.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{labels.LGTM},
+			issueLabels:       []string{labels.LGTM},
+		},
+		{
+			name:              "1 file 1 label, doesn't exist on the repo",
+			filesChanged:      []string{"b.go"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{labels.Approved},
+			issueLabels:       []string{},
+		},
+		{
+			name:              "2 files no overlap, 1 label already present",
+			filesChanged:      []string{"c.go", "d.sh"},
+			expectedNewLabels: formatLabels(labels.LGTM, "dnm/frozen-docs"),
+			repoLabels:        []string{"dnm/bash", labels.Approved, labels.LGTM, "dnm/frozen-docs"},
+			issueLabels:       []string{"dnm/bash", labels.Approved},
+		},
+		{
+			name:              "2 files complete overlap, label already present",
+			filesChanged:      []string{"d.sh", "e.sh"},
+			expectedNewLabels: []string{},
+			repoLabels:        []string{"dnm/bash"},
+			issueLabels:       []string{"dnm/bash"},
+		},
+	}
+
+	for _, tc := range testcases {
+		basicPR := github.PullRequest{
+			Number: 1,
+			Base: github.PullRequestBranch{
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+			},
+			User: github.User{
+				Login: "user",
+			},
+		}
+
+		t.Logf("Running scenario %q", tc.name)
+		sort.Strings(tc.expectedNewLabels)
+		changes := make([]github.PullRequestChange, 0, len(tc.filesChanged))
+		for _, name := range tc.filesChanged {
+			changes = append(changes, github.PullRequestChange{Filename: name})
+		}
+		fghc := &fakegithub.FakeClient{
+			PullRequests: map[int]*github.PullRequest{
+				basicPR.Number: &basicPR,
+			},
+			PullRequestChanges: map[int][]github.PullRequestChange{
+				basicPR.Number: changes,
+			},
+			RepoLabelsExisting: tc.repoLabels,
+			IssueLabelsAdded:   []string{},
+		}
+		// Add initial labels
+		for _, label := range tc.issueLabels {
+			fghc.AddLabel(basicPR.Base.Repo.Owner.Login, basicPR.Base.Repo.Name, basicPR.Number, label)
+		}
+		pre := &github.PullRequestEvent{
+			Action:      github.PullRequestActionOpened,
+			Number:      basicPR.Number,
+			PullRequest: basicPR,
+			Repo:        basicPR.Base.Repo,
+		}
+
+		err := handle(fghc, foc, logrus.WithField("plugin", PluginName), pre)
+		if err != nil {
+			t.Errorf("[%s] unexpected error from handle: %v", tc.name, err)
+			continue
+		}
+
+		// Check that all the correct labels (and only the correct labels) were added.
+		expectLabels := append(formatLabels(tc.issueLabels...), tc.expectedNewLabels...)
+		if expectLabels == nil {
+			expectLabels = []string{}
+		}
+		sort.Strings(expectLabels)
+		sort.Strings(fghc.IssueLabelsAdded)
+		if !reflect.DeepEqual(expectLabels, fghc.IssueLabelsAdded) {
+			t.Errorf("expected the labels %q to be added, but %q were added.", expectLabels, fghc.IssueLabelsAdded)
+		}
+
+	}
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -486,8 +486,11 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor fu
 			gqlc: githubql.NewEnterpriseClient(
 				graphqlEndpoint,
 				&http.Client{
-					Timeout:   maxRequestTime,
-					Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
+					Timeout: maxRequestTime,
+					Transport: &oauth2.Transport{
+						Source: newReloadingTokenSource(getToken),
+						Base:   newAddHeaderTransport(),
+					},
 				}),
 			client:        &http.Client{Timeout: maxRequestTime},
 			bases:         bases,
@@ -500,6 +503,21 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor fu
 			maxSleepTime:  defaultMaxSleepTime,
 		},
 	}
+}
+
+func newAddHeaderTransport() http.RoundTripper {
+	return &addHeaderTransport{}
+}
+
+type addHeaderTransport struct {
+}
+
+func (s *addHeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// We have to add this header to enable the Checks scheme preview:
+	// https://docs.github.com/en/enterprise-server@2.22/graphql/overview/schema-previews
+	// Any GHE version after 2.22 will enable the Checks types per default
+	r.Header.Add("Accept", "application/vnd.github.antiope-preview+json")
+	return http.DefaultTransport.RoundTrip(r)
 }
 
 // NewClient creates a new fully operational GitHub client.


### PR DESCRIPTION
This implements a hack to able to use the checks preview. Looks like that's necessary with GHE 2.22.2 but will be fixed with the next release (the Checks preview is not listed as preview any more on the latest doc)
https://docs.github.com/en/free-pro-team@latest/graphql/overview/schema-previews#checks-preview
vs.
https://docs.github.com/en/enterprise-server@2.22/graphql/overview/schema-previews

Support will be implemented here: https://github.com/kubernetes/test-infra/pull/19806/files